### PR TITLE
Fix/ci

### DIFF
--- a/.github/workflows/maven-central.yml
+++ b/.github/workflows/maven-central.yml
@@ -32,10 +32,6 @@ jobs:
         if: env.IS_CANCELLED == 'false'
         uses: ./.github/actions/setup-gradle
 
-      - name: Restore Gradle Build Cache
-        if: env.IS_CANCELLED == 'false'
-        uses: ./.github/actions/cache-gradle
-
       - name: Publish package
         if: env.IS_CANCELLED == 'false'
         run: ./gradlew publish # TODO: Note this is for all publish repos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,11 @@ jobs:
 
   dependency-submission:
     uses: ./.github/workflows/dependency-submission.yml
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   github-packages:
     uses: ./.github/workflows/github-packages.yml
     needs: [dokka, dependency-submission ]
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,11 @@ jobs:
 
   dependency-submission:
     uses: ./.github/workflows/dependency-submission.yml
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   github-packages:
     uses: ./.github/workflows/github-packages.yml
     needs: [dokka, dependency-submission ]
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,13 +18,13 @@ jobs:
 
   build:
     uses: ./.github/workflows/build.yml
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
-    env:
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    with:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
 
   # Only run for PRs created by dependabot after other all checks pass (i.e. build & unit tests)
   automerge-dependabot:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,6 +10,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  packages: read
 
 jobs:
   assign-author:
@@ -17,9 +18,13 @@ jobs:
 
   build:
     uses: ./.github/workflows/build.yml
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # Only run for PRs created by dependabot after other all checks pass (i.e. build & unit tests)
   automerge-dependabot:


### PR DESCRIPTION
This pull request includes updates to GitHub Actions workflows to enhance security and streamline the CI/CD process. The most significant changes involve removing an unused Gradle build cache step, adding environment variables for GitHub tokens, and updating permissions for workflows.

### Workflow simplifications:
* [`.github/workflows/maven-central.yml`](diffhunk://#diff-86988a3aa487714c26f1fafe0d2446a9490c50d1b06a485c553770153438fe0aL35-L38): Removed the "Restore Gradle Build Cache" step, as it was no longer needed in the workflow.

### Security improvements:
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R20-R27): Added `GITHUB_TOKEN` as an environment variable to the `dependency-submission` and `github-packages` jobs to ensure secure access to GitHub resources.
* [`.github/workflows/pull-request.yml`](diffhunk://#diff-b71166ed0f585913318ed46933ff9b12901e211de3ac88c40de03f0a944c0ae0R13-R27): Updated permissions to include `packages: read` and added `GITHUB_TOKEN` as an environment variable for the `build` and `unit-tests` jobs to securely authenticate API requests.