### PR TITLE
fix: gh token

### DIFF
--- a/.github/workflows/assign-author.yml
+++ b/.github/workflows/assign-author.yml
@@ -11,5 +11,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: toshimaru/auto-author-assign@v2.1.1
-        with:
+        secrets:
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -3,6 +3,7 @@ name: Automerge Dependabot
 on:
   workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
   workflow_call: # Allows this workflow to be called from other workflows.
+    secrets: inherit
 
 jobs:
   automerge-dependabot-job:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ name: Build
 on:
   workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
   workflow_call: # Allows this workflow to be called from other workflows.
+    secrets: inherit
 
 jobs:
   build:
@@ -15,3 +16,5 @@ jobs:
 
       - name: Execute Gradle Build
         run: ./gradlew build
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -3,6 +3,7 @@ name: Dependency Submission
 on:
   workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
   workflow_call: # Allows this workflow to be called from other workflows.
+    secrets: inherit
 
 permissions:
   contents: write

--- a/.github/workflows/github-packages.yml
+++ b/.github/workflows/github-packages.yml
@@ -4,13 +4,16 @@ name: Publish to GitHub Packages
 on:
   workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
   workflow_call: # Allows this workflow to be called from other workflows.
+    secrets: inherit
 
 jobs:
   publish:
     runs-on: ubuntu-latest
+
     permissions:
       contents: read
       packages: write
+
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,11 +17,11 @@ jobs:
 
   dependency-submission:
     uses: ./.github/workflows/dependency-submission.yml
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   github-packages:
     uses: ./.github/workflows/github-packages.yml
     needs: [dokka, dependency-submission ]
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,13 +18,13 @@ jobs:
 
   build:
     uses: ./.github/workflows/build.yml
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   unit-tests:
     uses: ./.github/workflows/unit-tests.yml
-    with:
-      github-token: ${{ secrets.GITHUB_TOKEN }}
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
 
   # Only run for PRs created by dependabot after other all checks pass (i.e. build & unit tests)
   automerge-dependabot:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -3,6 +3,7 @@ name: Unit Tests
 on:
   workflow_dispatch: # Manual dispatch from the Actions tab in GitHub.
   workflow_call: # Allows this workflow to be called from other workflows.
+    secrets: inherit
 
 jobs:
   unit-tests:
@@ -15,6 +16,8 @@ jobs:
 
       - name: Run Unit Tests
         run: ./gradlew check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Reports
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to standardize the handling of secrets by using the `secrets` key instead of the `with` key for passing tokens and by inheriting secrets in reusable workflows. These changes improve security and consistency across workflows.

### Standardizing secrets handling in reusable workflows:

* Added the `secrets: inherit` configuration to the `workflow_call` trigger in `.github/workflows/build.yml`, `.github/workflows/dependency-submission.yml`, `.github/workflows/github-packages.yml`, and `.github/workflows/unit-tests.yml` to ensure secrets are passed to reusable workflows. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R6-R11) [[2]](diffhunk://#diff-de11555715601722f2c4b4bd88866a2bd84a17f0669cbc66f60cf25040bb2e3cR6-R14) [[3]](diffhunk://#diff-6d649d6d8f25b0112ff1f392579ef42f74db557f6769be846432f2c451a71087R7-R17) [[4]](diffhunk://#diff-cd0effce06f425599e96952f4d5f684641a683f46d9909e7c74a9f8b2f03ccd3R6-R11)

### Replacing `with` key with `secrets` key for token passing:

* Updated `.github/workflows/publish.yml` to use the `secrets` key for passing the `GITHUB_TOKEN` to the `dependency-submission` and `github-packages` jobs.
* Updated `.github/workflows/pull-request.yml` to use the `secrets` key for passing the `GITHUB_TOKEN` to the `build` and `unit-tests` jobs.