### PR TITLE
Refactor/outcome

### DIFF
--- a/src/main/kotlin/nz/adjmunro/knomadic/fetch/FetchDsl.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/fetch/FetchDsl.kt
@@ -1,7 +1,7 @@
-package nz.adjmunro.knomadic.raise
+package nz.adjmunro.knomadic.fetch
 
 /**
- * Annotation marking members of the [RaiseScope] DSL.
+ * Annotation marking members of the [Fetch] DSL.
  */
 @Target(
     AnnotationTarget.FILE,
@@ -12,4 +12,4 @@ package nz.adjmunro.knomadic.raise
     AnnotationTarget.PROPERTY,
 )
 @DslMarker @PublishedApi
-internal annotation class RaiseDsl
+internal annotation class FetchDsl

--- a/src/main/kotlin/nz/adjmunro/knomadic/fetch/flow/FlowAccessors.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/fetch/flow/FlowAccessors.kt
@@ -9,7 +9,6 @@ import nz.adjmunro.knomadic.fetch.members.getOrDefault
 import nz.adjmunro.knomadic.fetch.members.getOrElse
 import nz.adjmunro.knomadic.fetch.members.getOrNull
 import nz.adjmunro.knomadic.fetch.members.getOrThrow
-import nz.adjmunro.knomadic.fetch.members.unwrap
 
 /**
  * @return A [Flow] of the [result][Fetch.Finished.result] of a [Fetch] or the [default] value.
@@ -44,28 +43,4 @@ public fun <T: Any> FetchFlow<T>.fetchOrNull(): Flow<T?> {
 @KnomadicDsl
 public fun <T: Any> FetchFlow<T>.fetchOrThrow(): Flow<T> {
     return map { it.getOrThrow() }
-}
-
-/**
- * Attempt to unwrap a [FetchFlow] to produce a [Flow] of it's [result][Fetch.Finished.result].
- *
- * ```kotlin
- * val fetch: Fetch<String> = Fetch.Initial
- * fetch.unwrap()           // getOrThrow() (default behaviour)
- * fetch.unwrap { null }    // getOrNull() (initial & fetching to null)
- * fetch.unwrap { "$it" }   // getOrElse() (initial & fetching to string)
- * ```
- *
- * @return A [Flow] of the [result][Fetch.Finished.result] of a [Fetch] or the result of [recover].
- * @throws IllegalStateException if default [recover] value is used and fetch is [initial][Fetch.Initial] or [in progress][Fetch.Fetching].
- * @see FetchFlow.fetchOrThrow
- * @see FetchFlow.fetchOrNull
- * @see FetchFlow.fetchOrElse
- * @see FetchFlow.fetchOrDefault
- */
-@KnomadicDsl
-public inline fun <T> FetchFlow<T & Any>.fetchUnwrap(
-    crossinline recover: suspend (Fetch<T & Any>) -> T = { error("Fetch has not finished!") },
-): Flow<T> {
-    return map { it.unwrap() }
 }

--- a/src/main/kotlin/nz/adjmunro/knomadic/fetch/members/Accessors.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/fetch/members/Accessors.kt
@@ -18,7 +18,7 @@ public infix fun <T: Any> Fetch<T>.getOrDefault(default: T): T {
  * @return The [result][Fetch.Finished.result] of a [Fetch] or the result of [recover].
  */
 @KnomadicDsl
-public inline fun <T: Any> Fetch<T>.getOrElse(recover: (Fetch<T>) -> T): T {
+public inline fun <T> Fetch<T & Any>.getOrElse(recover: (Fetch<T & Any>) -> T): T {
     return fold(initial = { recover(this) }, fetching = { recover(this) }, finished = ::itself)
 }
 
@@ -48,28 +48,4 @@ public fun <T: Any> Fetch<T>.getOrThrow(): T {
         fetching = { error("Fetch has not finished!") },
         finished = ::itself,
     )
-}
-
-/**
- * Attempt to unwrap a [Fetch] to obtain it's [result][Fetch.Finished.result] value.
- * 
- * ```kotlin
- * val fetch: Fetch<String> = Fetch.Initial
- * fetch.unwrap()           // getOrThrow() (default behaviour)
- * fetch.unwrap { null }    // getOrNull() (initial & fetching to null)
- * fetch.unwrap { "$it" }   // getOrElse() (initial & fetching to string)
- * ```
- * 
- * @return The [result][Fetch.Finished.result] of a [Fetch] or the result of [recover].
- * @throws IllegalStateException if default [recover] value is used and fetch is [initial][Fetch.Initial] or [in progress][Fetch.Fetching].
- * @see Fetch.getOrThrow
- * @see Fetch.getOrNull
- * @see Fetch.getOrElse
- * @see Fetch.getOrDefault
- */
-@KnomadicDsl
-public inline fun <T> Fetch<T & Any>.unwrap(
-    recover: (Fetch<T & Any>) -> T = { error("Fetch has not finished!") },
-): T {
-    return fold(initial = { recover(this) }, fetching = { recover(this) }, finished = ::itself)
 }

--- a/src/main/kotlin/nz/adjmunro/knomadic/outcome/Outcome.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/outcome/Outcome.kt
@@ -3,6 +3,7 @@ package nz.adjmunro.knomadic.outcome
 import nz.adjmunro.knomadic.KotlinResult
 import nz.adjmunro.knomadic.outcome.members.errorOrNull
 import nz.adjmunro.knomadic.outcome.members.getOrNull
+import nz.adjmunro.knomadic.outcome.members.outcomeOf
 
 /**
  * Represents either a [Success] or [Failure] state.
@@ -18,7 +19,6 @@ import nz.adjmunro.knomadic.outcome.members.getOrNull
  */
 @OutcomeDsl
 public sealed interface Outcome<out Ok : Any, out Error : Any> {
-
     public operator fun component1(): Ok? = getOrNull()
     public operator fun component2(): Error? = errorOrNull()
 }

--- a/src/main/kotlin/nz/adjmunro/knomadic/outcome/OutcomeDsl.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/outcome/OutcomeDsl.kt
@@ -11,5 +11,5 @@ package nz.adjmunro.knomadic.outcome
     AnnotationTarget.FUNCTION,
     AnnotationTarget.PROPERTY,
 )
-@DslMarker
-public annotation class OutcomeDsl
+@DslMarker @PublishedApi
+internal annotation class OutcomeDsl

--- a/src/main/kotlin/nz/adjmunro/knomadic/outcome/members/BuildOutcome.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/outcome/members/BuildOutcome.kt
@@ -3,6 +3,7 @@
 package nz.adjmunro.knomadic.outcome.members
 
 import nz.adjmunro.inline.itself
+import nz.adjmunro.inline.nulls
 import nz.adjmunro.inline.rethrow
 import nz.adjmunro.knomadic.outcome.Failure
 import nz.adjmunro.knomadic.outcome.Faulty
@@ -102,7 +103,7 @@ public inline fun <In, Out : Any, Error : Any> In.failureOf(block: (In) -> Error
  */
 @OutcomeDsl
 public inline fun <Ok : Any> catch(
-    @BuilderInference block: RaiseScope<Throwable>.() -> Ok,
+    block: RaiseScope<Throwable>.() -> Ok,
 ): Outcome<Ok, Throwable> = outcomeOf(catch = ::Failure, block = block)
 
 /**
@@ -120,7 +121,7 @@ public inline fun <Ok : Any> catch(
  */
 @OutcomeDsl
 public inline fun <In, Out : Any> In.catch(
-    @BuilderInference block: RaiseScope<Throwable>.(In) -> Out,
+    block: RaiseScope<Throwable>.(In) -> Out,
 ): Outcome<Out, Throwable> = outcomeOf(catch = ::Failure, block = block)
 
 /**
@@ -137,7 +138,7 @@ public inline fun <In, Out : Any> In.catch(
  */
 @OutcomeDsl
 public inline fun <Ok : Any> outcome(
-    @BuilderInference block: RaiseScope<String>.() -> Ok,
+    block: RaiseScope<String>.() -> Ok,
 ): Outcome<Ok, String> = outcomeOf(
     catch = { e: Throwable -> Failure(error = e.message ?: e.toString()) },
     block = block
@@ -158,7 +159,7 @@ public inline fun <Ok : Any> outcome(
  */
 @OutcomeDsl
 public inline fun <In, Out : Any> In.outcome(
-    @BuilderInference block: RaiseScope<String>.(In) -> Out,
+    block: RaiseScope<String>.(In) -> Out,
 ): Outcome<Out, String> = outcomeOf(
     catch = { e: Throwable -> Failure(error = e.message ?: e.toString()) },
     block = block
@@ -197,15 +198,8 @@ public inline fun <In, Out : Any> In.outcome(
 public inline fun <Ok : Any, Error : Any> outcomeOf(
     catch: (throwable: Throwable) -> Outcome<Ok, Error> = ::rethrow,
     @BuilderInference block: RaiseScope<Error>.() -> Ok,
-): Outcome<Ok, Error> {
-    return RaiseScope.default {
-        fold(
-            block = block,
-            catch = catch,
-            recover = ::Failure,
-            transform = ::Success,
-        )
-    }
+): Outcome<Ok, Error> = RaiseScope.default {
+    fold(block = block, catch = catch, recover = ::Failure, transform = ::Success)
 }
 
 /**
@@ -244,15 +238,13 @@ public inline fun <Ok : Any, Error : Any> outcomeOf(
 public inline fun <In, Out: Any, Error : Any> In.outcomeOf(
     catch: (throwable: Throwable) -> Outcome<Out, Error> = ::rethrow,
     @BuilderInference block: RaiseScope<Error>.(In) -> Out,
-): Outcome<Out, Error> {
-    return RaiseScope.default {
-        fold(
-            block = { block(this@outcomeOf) },
-            catch = catch,
-            recover = ::Failure,
-            transform = ::Success,
-        )
-    }
+): Outcome<Out, Error> = RaiseScope.default {
+    fold(
+        block = { block(this@outcomeOf) },
+        catch = catch,
+        recover = ::Failure,
+        transform = ::Success,
+    )
 }
 
 /**
@@ -274,17 +266,8 @@ public inline fun <In, Out: Any, Error : Any> In.outcomeOf(
 @OutcomeDsl
 public inline fun <Ok : Any> maybeOf(
     @BuilderInference catch: (throwable: Throwable) -> Maybe<Ok> = ::emptyFailure,
-    @BuilderInference block: RaiseScope<Any>.() -> Ok,
-): Maybe<Ok> {
-    return RaiseScope.default<Maybe<Ok>, Any> {
-        fold(
-            block = block,
-            catch = catch,
-            recover = ::emptyFailure,
-            transform = ::Success,
-        )
-    }
-}
+    block: RaiseScope<Unit>.() -> Ok,
+): Maybe<Ok> = outcomeOf(catch = catch, block = block)
 
 /**
  * Context runner that encapsulates the result of [block] as a [Maybe].
@@ -307,17 +290,8 @@ public inline fun <Ok : Any> maybeOf(
 @OutcomeDsl
 public inline fun <In, Out : Any> In.maybeOf(
     @BuilderInference catch: (throwable: Throwable) -> Maybe<Out> = ::rethrow,
-    @BuilderInference block: RaiseScope<Any>.(In) -> Out,
-): Maybe<Out> {
-    return RaiseScope.default<Maybe<Out>, Any> {
-        fold(
-            block = { block(this@maybeOf) },
-            catch = catch,
-            recover = ::emptyFailure,
-            transform = ::Success,
-        )
-    }
-}
+    block: RaiseScope<Unit>.(In) -> Out,
+): Maybe<Out> = outcomeOf(catch = catch, block = block)
 
 /**
  * Context runner that encapsulates the result of [block] as a [Faulty].
@@ -339,16 +313,7 @@ public inline fun <In, Out : Any> In.maybeOf(
 public inline fun <Error : Any> faultyOf(
     @BuilderInference catch: (throwable: Throwable) -> Faulty<Error> = ::rethrow,
     @BuilderInference block: RaiseScope<Error>.() -> Unit,
-): Faulty<Error> {
-    return RaiseScope.default<Faulty<Error>, Error> {
-        fold(
-            block = block,
-            catch = catch,
-            recover = ::Failure,
-            transform = ::emptySuccess,
-        )
-    }
-}
+): Faulty<Error> = outcomeOf(catch = catch, block = block)
 
 /**
  * Context runner that encapsulates the result of [block] as a [Faulty].
@@ -371,16 +336,7 @@ public inline fun <Error : Any> faultyOf(
 public inline fun <In, Error : Any> In.faultyOf(
     @BuilderInference catch: (throwable: Throwable) -> Faulty<Error> = ::rethrow,
     @BuilderInference block: RaiseScope<Error>.(In) -> Unit,
-): Faulty<Error> {
-    return RaiseScope.default<Faulty<Error>, Error> {
-        fold(
-            block = { block(this@faultyOf) },
-            catch = catch,
-            recover = ::Failure,
-            transform = ::emptySuccess,
-        )
-    }
-}
+): Faulty<Error> = outcomeOf(catch = catch, block = block)
 
 /**
  * Context runner that uses [RaiseScope] to safely capture raised or thrown errors,
@@ -393,18 +349,11 @@ public inline fun <In, Error : Any> In.faultyOf(
  * @return The result of the [block] if successful, or the result of the [fallback] function if an error occurs.
  */
 @OutcomeDsl
-public inline fun <T: Any> safe(
+public inline fun <T: Any> safely(
     crossinline fallback: (Any) -> T,
-    @BuilderInference block: RaiseScope<Unit>.() -> T,
-) : T {
-    return RaiseScope.default {
-        fold(
-            block = block,
-            catch = fallback,
-            recover = fallback,
-            transform = ::itself
-        )
-    }
+    block: RaiseScope<Unit>.() -> T,
+) : T = RaiseScope.default {
+    fold(block = block, catch = fallback, recover = fallback, transform = ::itself)
 }
 
 /**
@@ -419,16 +368,47 @@ public inline fun <T: Any> safe(
  * @return The result of the [block] if successful, or the result of the [fallback] function if an error occurs.
  */
 @OutcomeDsl
-public inline fun <In, Out: Any> In.safe(
+public inline fun <In, Out: Any> In.safely(
     crossinline fallback: (Any) -> Out,
-    @BuilderInference block: RaiseScope<Unit>.(In) -> Out,
-) : Out {
-    return RaiseScope.default {
-        fold(
-            block = { block(this@safe) },
-            catch = fallback,
-            recover = fallback,
-            transform = ::itself
-        )
-    }
+    block: RaiseScope<Unit>.(In) -> Out,
+) : Out = RaiseScope.default {
+    fold(block = { block(this@safely) }, catch = fallback, recover = fallback, transform = ::itself)
+}
+
+/**
+ * Context runner that uses [RaiseScope] to safely capture raised
+ * or thrown errors, and unwraps either the successful [Outcome] or `null`.
+ *
+ * > Used in scenarios where you want the advantages of [Outcome], but immediately
+ * > resolve to its [Ok][Success] type or `null`.
+ *
+ * @param block The code to execute within the [RaiseScope].
+ * @return The result of the [block] if successful, or `null` if an error occurs.
+ */
+@OutcomeDsl
+public inline fun <T: Any> nullableOf(block: RaiseScope<Unit>.() -> T) : T? = RaiseScope.default {
+    fold(block = block, catch = ::nulls, recover = ::nulls, transform = ::itself)
+}
+
+/**
+ * Context runner that uses [RaiseScope] to safely capture raised
+ * or thrown errors, and unwraps either the successful [Outcome] or `null`.
+ *
+ * > Used in scenarios where you want the advantages of [Outcome], but immediately
+ * > resolve to its [Ok][Success] type or `null`.
+ *
+ * @receiver Some input type, [In], passed to [block].
+ * @param block The code to execute within the [RaiseScope].
+ * @return The result of the [block] if successful, or `null` if an error occurs.
+ */
+@OutcomeDsl
+public inline fun <In, Out: Any> In.nullableOf(
+    block: RaiseScope<Unit>.(In) -> Out,
+) : Out? = RaiseScope.default {
+    fold(
+        block = { block(this@nullableOf) },
+        catch = ::nulls,
+        recover = ::nulls,
+        transform = ::itself,
+    )
 }

--- a/src/main/kotlin/nz/adjmunro/knomadic/outcome/members/GetOutcome.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/outcome/members/GetOutcome.kt
@@ -17,10 +17,10 @@ public infix fun <Ok : Any, Error : Any> Outcome<Ok, Error>.getOrDefault(default
 
 /** @return The [value][Success] or the result of [recover]. */
 @OutcomeDsl
-public inline infix fun <Ok : Any, Error : Any> Outcome<Ok, Error>.getOrElse(
+public inline infix fun <Ok, Error : Any> Outcome<Ok & Any, Error>.getOrElse(
     recover: (Error) -> Ok,
 ): Ok {
-    return fold(success = Success<Ok>::value, failure = { recover(error) })
+    return fold(success = Success<Ok & Any>::value, failure = { recover(error) })
 }
 
 /** @return The [value][Success] or `null`. */
@@ -47,33 +47,6 @@ public fun <Ok : Any, Error : Any> Outcome<Ok, Error>.getOrThrow(): Ok {
     }
 }
 
-/**
- * Attempt to unwrap [Outcome] into an [Ok] value.
- *
- * > **Be warned: [recover] throws by default!**
- * 
- * ```kotlin
- * val outcome: Outcome<String, Throwable> = ...
- * outcome.unwrap()         // getOrThrow() (default behaviour)
- * outcome.unwrap { null }  // getOrNull() (map Error to null)
- * outcome.unwrap { "$it" } // getOrElse() (map Error to fallback value)
- * ```
- *
- * @param recover A function that maps the [Error] value to an [Ok] value.
- * @return The [value][Success.value] or the result of [recover].
- * @throws IllegalStateException if the [Outcome] is a [failure][Failure], by default.
- * @see Outcome.getOrThrow
- * @see Outcome.getOrNull
- * @see Outcome.getOrElse
- * @see Outcome.unwrapError
- */
-@OutcomeDsl
-public inline infix fun <Ok, Error : Any> Outcome<Ok & Any, Error>.unwrap(
-    recover: (Error) -> Ok = { error("Outcome::unwrap threw! Got: $this") },
-): Ok {
-    return fold(success = Success<Ok & Any>::value, failure = { recover(error) })
-}
-
 /** @return The [error][Failure] or [default]. */
 @OutcomeDsl
 public infix fun <Ok : Any, Error : Any> Outcome<Ok, Error>.errorOrDefault(default: Error): Error {
@@ -82,10 +55,10 @@ public infix fun <Ok : Any, Error : Any> Outcome<Ok, Error>.errorOrDefault(defau
 
 /** @return The [error][Failure] or the result of [faulter]. */
 @OutcomeDsl
-public inline infix fun <Ok : Any, Error : Any> Outcome<Ok, Error>.errorOrElse(
+public inline infix fun <Ok : Any, Error> Outcome<Ok, Error & Any>.errorOrElse(
     faulter: (Ok) -> Error,
 ): Error {
-    return fold(success = { faulter(value) }, failure = Failure<Error>::error)
+    return fold(success = { faulter(value) }, failure = Failure<Error & Any>::error)
 }
 
 /** @return The [error][Failure] or `null`. */
@@ -112,31 +85,4 @@ public fun <Ok : Any, Error : Any> Outcome<Ok, Error>.errorOrThrow(): Error {
     return fold(failure = Failure<Error>::error) {
         value.throwfold(throws = ::rethrow) { error("Outcome::errorOrThrow threw! Got: $this") }
     }
-}
-
-/**
- * Attempt to unwrap [Outcome] into an [Error] value.
- *
- * > **Be warned: [faulter] throws by default!**
- * 
- * ```kotlin
- * val outcome: Outcome<String, Throwable> = ...
- * outcome.unwrapError()         // errorOrThrow() (default behaviour)
- * outcome.unwrapError { null }  // errorOrNull() (map Ok to null)
- * outcome.unwrapError { "$it" } // errorOrElse() (map Ok to fallback value)
- * ```
- *
- * @param faulter A function that maps the [Ok] value to an [Error] value.
- * @return The [error][Failure.error] or the result of [faulter].
- * @throws IllegalStateException if the [Outcome] is a [success][Success], by default.
- * @see Outcome.errorOrThrow
- * @see Outcome.errorOrNull
- * @see Outcome.errorOrElse
- * @see Outcome.unwrap
- */
-@OutcomeDsl
-public inline infix fun <Ok: Any, Error> Outcome<Ok, Error & Any>.unwrapError(
-    faulter: (Ok) -> Error = { error("Outcome::unwrapError threw! Got: $this") },
-): Error {
-    return fold(success = { faulter(value) }, failure = Failure<Error & Any>::error)
 }

--- a/src/main/kotlin/nz/adjmunro/knomadic/outcome/members/IterateOutcome.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/outcome/members/IterateOutcome.kt
@@ -4,8 +4,6 @@ import nz.adjmunro.knomadic.outcome.Failure
 import nz.adjmunro.knomadic.outcome.Outcome
 import nz.adjmunro.knomadic.outcome.OutcomeDsl
 import nz.adjmunro.knomadic.outcome.Success
-import nz.adjmunro.knomadic.outcome.members.errorOrThrow
-import nz.adjmunro.knomadic.outcome.members.getOrThrow
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 

--- a/src/main/kotlin/nz/adjmunro/knomadic/raise/RaiseScope.kt
+++ b/src/main/kotlin/nz/adjmunro/knomadic/raise/RaiseScope.kt
@@ -79,7 +79,7 @@ public sealed interface RaiseScope<in Error : Any> {
          * @throws Throwable if [catch] re-throws.
          */
         @RaiseDsl
-        public inline fun <Ok : Any, Error : Any> RaiseScope<Error>.catch(
+        public inline fun <Ok, Error : Any> RaiseScope<Error>.catch(
             catch: (throwable: Throwable) -> Error = ::rethrow,
             @BuilderInference block: RaiseScope<Error>.() -> Ok,
         ): Ok {
@@ -94,7 +94,7 @@ public sealed interface RaiseScope<in Error : Any> {
         }
 
         @RaiseDsl
-        public inline fun <Ok : Any, Error : Any> Companion.default(
+        public inline fun <Ok, Error : Any> Companion.default(
             @BuilderInference action: RaiseScope<Error>.() -> Ok,
         ): Ok = with(receiver = DefaultRaise(), block = action)
 
@@ -120,7 +120,7 @@ public sealed interface RaiseScope<in Error : Any> {
 
         @RaiseDsl
         @Suppress("UNCHECKED_CAST")
-        public inline fun <In : Any, Out : Any, Error : Any> RaiseScope<Error>.fold(
+        public inline fun <In, Out, Error : Any> RaiseScope<Error>.fold(
             block: (scope: RaiseScope<Error>) -> In,
             catch: (throwable: Throwable) -> Out = ::rethrow,
             recover: (error: Error) -> Out,


### PR DESCRIPTION
This pull request includes changes to the `Fetch` and `Outcome` DSLs, focusing on improving type safety, simplifying APIs, and removing redundant methods. Key changes include the addition of internal annotations, adjustments to type constraints, and the removal of the `unwrap` methods in favor of more explicit alternatives.

### Fetch DSL Changes:
* Added the `FetchDsl` annotation to mark members of the `Fetch` DSL, improving clarity and encapsulation (`src/main/kotlin/nz/adjmunro/knomadic/fetch/FetchDsl.kt`).
* Removed the `fetchUnwrap` extension function, streamlining the API by encouraging the use of more specific methods like `fetchOrThrow`, `fetchOrNull`, etc. (`src/main/kotlin/nz/adjmunro/knomadic/fetch/flow/FlowAccessors.kt`).
* Adjusted type constraints in `getOrElse` to improve type safety (`src/main/kotlin/nz/adjmunro/knomadic/fetch/members/Accessors.kt`).

### Outcome DSL Changes:
* Updated the `OutcomeDsl` annotation to be internal and added `@PublishedApi` for better encapsulation (`src/main/kotlin/nz/adjmunro/knomadic/outcome/OutcomeDsl.kt`).
* Simplified the implementation of context runners like `outcomeOf`, `maybeOf`, and `faultyOf`, reducing boilerplate and improving maintainability (`src/main/kotlin/nz/adjmunro/knomadic/outcome/members/BuildOutcome.kt`) [[1]](diffhunk://#diff-65d600b6f7d839de7b3ff8a374ca185887a34548199a1927bafdb3b92e1c7af0L200-R202) [[2]](diffhunk://#diff-65d600b6f7d839de7b3ff8a374ca185887a34548199a1927bafdb3b92e1c7af0L277-R270) [[3]](diffhunk://#diff-65d600b6f7d839de7b3ff8a374ca185887a34548199a1927bafdb3b92e1c7af0L374-R339).
* Introduced `nullableOf` functions to safely capture errors and return nullable results, providing a new utility for handling outcomes (`src/main/kotlin/nz/adjmunro/knomadic/outcome/members/BuildOutcome.kt`).

### Removal of `unwrap` Methods:
* Removed `unwrap` and `unwrapError` methods from both `Fetch` and `Outcome` APIs. These methods were replaced with more explicit alternatives like `getOrThrow`, `getOrElse`, and `errorOrElse` to improve readability and reduce ambiguity (`src/main/kotlin/nz/adjmunro/knomadic/fetch/members/Accessors.kt`, `src/main/kotlin/nz/adjmunro/knomadic/outcome/members/GetOutcome.kt`) [[1]](diffhunk://#diff-d9da9473d8fd3a13e094ceb3489f7237bc793b97e8805ff3704bfb6c5a164f4cL52-L75) [[2]](diffhunk://#diff-dff2182e6d9ca36781688101b522ddacdd9b3777fc12135ff2f4311e1c7af179L50-L76).